### PR TITLE
Added multi response example

### DIFF
--- a/openman/spec/collector/response.py
+++ b/openman/spec/collector/response.py
@@ -1,0 +1,95 @@
+from openman.utils import camelize
+
+
+class ResponseCollector:
+    def __init__(self):
+        self.responses = {}
+        self.examples = {}
+        self.contents = {}
+
+    @staticmethod
+    def get_unique_key(code, content_type):
+        return f"{code}/{content_type}"
+
+    def add_example(self, code, content_type, title, example, **kwargs):
+        title = camelize(title)
+        example = {
+            "value": example,
+            "x-response-id": kwargs.pop("response_id", ""),
+        }
+        if code in self.examples.keys():
+            if content_type in self.examples[code].keys():
+                self.examples[code][content_type][title] = example
+            else:
+                self.examples[code][content_type] = dict()
+                self.examples[code][content_type][title] = example
+        else:
+            self.examples[code] = dict()
+            self.examples[code][content_type] = dict()
+            self.examples[code][content_type][title] = example
+
+    def add_content(self, code, content_type, title, schema):
+        schema["title"] = title
+        key = self.get_unique_key(code, content_type)
+        if key not in self.contents.keys():
+            self.contents[key] = schema
+        else:
+            if "oneOf" in self.contents[key].keys():
+                self.contents[key]["oneOf"] += [schema]
+            else:
+                self.contents[key] = {"oneOf": [self.contents[key], schema]}
+
+    def get_schema(self, code, content_type):
+        key = self.get_unique_key(code, content_type)
+        return self.contents[key]
+
+    def get_example(self, code, content_type):
+        return self.examples[code][content_type]
+
+    def get_content(self, code, content_type):
+        schema = self.get_schema(code, content_type)
+        examples = self.get_example(code, content_type)
+        content = dict()
+        content[content_type] = dict(schema=schema, examples=examples)
+        return content
+
+    def add_response(self, code, content_type, title):
+        self.responses[code] = dict(
+            content=self.get_content(code, content_type), description=title
+        )
+
+    def collect(self):
+        return self.responses
+
+    def add(self, code, content_type, schema, title, example, **kwargs):
+        self.add_example(code, content_type, title, example, **kwargs)
+        self.add_content(code, content_type, title, schema)
+        self.add_response(code, content_type, title)
+        # response_examples[camelize(response.description)] = {"value": response.body, 'x-response-id': response.id}
+        """
+            if response_contents.get(key, None) is None:
+                response_contents[key] = schema
+            else:
+                toins = None
+                if "oneOf" in response_contents[key].keys():
+                    toins = response_contents[key]['oneOf']
+                    toins.append(schema)
+                else:
+                    toins = [response_contents[key], schema]
+                response_contents[key] = {"oneOf": toins}
+            response_content = dict()
+            response_content[response.content_type] = dict(
+                schema = response_contents[key],
+                examples = response_examples
+                # examples = {
+                    # camelize(response.description): {
+                        # 'value': response.body,
+                        # 'x-response-id': response.id
+                    # },
+                # },
+            )
+            response_schema[int(response.code)] = dict(
+                content = response_content,
+                description = response.description
+            )
+        """

--- a/openman/spec/operation.py
+++ b/openman/spec/operation.py
@@ -1,83 +1,79 @@
-import json
 from ..schema_converter import SchemaConvertor
 from ..utils import camelize, DEFAULT_STATUS_CODE
+from openman.spec.collector.response import ResponseCollector
+
 
 class Operation(object):
-
     def __init__(self, request_item, ignorespec=None):
         self.request_item = request_item
         self.ignorespec = ignorespec
-    
+
     def get_path(self, normalized=False):
         return self.request_item.get_request().get_path(normalized)
-    
+
     def get_method(self):
         return self.request_item.get_request().get_method()
 
     def id(self):
-        return camelize(self.get_path(True) +' '+ self.get_method())
-    
+        return camelize(self.get_path(True) + " " + self.get_method())
+
     def get_ignores(self, path, method, code):
         if not self.ignorespec:
             return []
-        if 'schema' not in self.ignorespec:
+        if "schema" not in self.ignorespec:
             return []
-        for _path, schemas in self.ignorespec['schema'].items():
+        for _path, schemas in self.ignorespec["schema"].items():
             if camelize(_path) == camelize(str(path)):
                 for _method, responsecode in schemas.items():
                     if _method == method:
                         return responsecode.get(int(code), [])
         return []
-        
+
     def get(self):
         _operation = dict()
         method = self.get_method()
         _operation[method] = dict(
-            operationId = self.id(),
-            summary = self.request_item.summary,
+            operationId=self.id(),
+            summary=self.request_item.summary,
         )
 
         if self.request_item.description:
-            _operation[method]['description'] = self.request_item.description
+            _operation[method]["description"] = self.request_item.description
 
-        #params
+        # params
         params = self.parameters()
         if len(params):
-            _operation[method]['parameters'] = params
-        
-        #request body
+            _operation[method]["parameters"] = params
+
+        # request body
         requestbody = self.request_body()
         if requestbody:
-            _operation[method]['requestBody'] = requestbody
-        
-        #responses
-        _operation[method]['responses'] = self.responses() or\
-             {DEFAULT_STATUS_CODE: {'description': ''}}
-        
-        return  _operation
+            _operation[method]["requestBody"] = requestbody
+
+        # responses
+        _operation[method]["responses"] = self.responses() or {
+            DEFAULT_STATUS_CODE: {"description": ""}
+        }
+
+        return _operation
 
     def responses(self):
-        response_schema = dict()
+        collector = ResponseCollector()
         for response in self.request_item.get_responses():
-            ignoreschema = self.get_ignores(self.get_path(), self.get_method(), response.code)
+            ignoreschema = self.get_ignores(
+                self.get_path(), self.get_method(), response.code
+            )
             schema = SchemaConvertor.convert(response.body, ignore=ignoreschema)
-            exampleDescription = self.id() + str(response.code)
-            response_content = dict()
-            response_content[response.content_type] = dict(
-                schema = schema,
-                examples = {
-                    camelize(response.description): {
-                        'value': response.body,
-                        'x-response-id': response.id
-                    },
-                },
+            collector.add(
+                response.code,
+                response.content_type,
+                schema,
+                response.description,
+                response.body,
+                response_id = response.id
             )
-            response_schema[int(response.code)] = dict(
-                content = response_content,
-                description = response.description
-            )
-        return response_schema
-    
+        return collector.collect()
+
     def append_param_example(self, location, name, responses=None):
         """
         This extracts the param `name` in `location` (ex- query, header etc)
@@ -92,15 +88,14 @@ class Operation(object):
             try:
                 for _name, _value in getattr(example_request, location).items():
                     if name == _name:
-                        links.append({
-                            'value': _value,
-                            'x-response-id': response.id
-                        })
+                        links.append(
+                            {"value": _value, "x-response-id": response.id}
+                        )
                         break
             except AttributeError as e:
-                pass                
+                pass
         return links
-    
+
     def append_body_example(self, location, name, responses=None):
         """
         This extracts the param `name` in `location` (ex- query, header etc)
@@ -112,12 +107,14 @@ class Operation(object):
         for response in responses:
             example_request = response.get_example()
             if example_request.body:
-                links.append({
-                    'value': example_request.body,
-                    'x-response-id': response.id
-                })  
+                links.append(
+                    {
+                        "value": example_request.body,
+                        "x-response-id": response.id,
+                    }
+                )
         return links
-    
+
     def parameters(self):
         """
         Constructs OpenAPI Spec compatible parameters spec
@@ -131,44 +128,49 @@ class Operation(object):
         if isinstance(request.query_string, dict):
             for name, value in request.query_string.items():
                 query_params = dict()
-                query_params['in'] =  'query'
-                query_params['name'] = name
-                query_params['schema'] = SchemaConvertor.convert(value)
-                query_params['schema'].update(dict(example=value))
-                query_params['x-link-response'] = []
+                query_params["in"] = "query"
+                query_params["name"] = name
+                query_params["schema"] = SchemaConvertor.convert(value)
+                query_params["schema"].update(dict(example=value))
+                query_params["x-link-response"] = []
                 # Check if any response has this param in their request
-                query_params['x-link-response'] = self.append_param_example('query_string', name, responses)
+                query_params["x-link-response"] = self.append_param_example(
+                    "query_string", name, responses
+                )
 
                 params.append(query_params)
-        
+
         # Build headers params
         if isinstance(request.headers, dict):
             for name, value in request.headers.items():
                 header_params = dict()
-                header_params['in'] =  'header'
-                header_params['name'] = name
-                header_params['schema'] = SchemaConvertor.convert(value)
-                header_params['schema'].update(dict(example=value))
-                header_params['x-link-response'] = self.append_param_example('headers', name, responses)
+                header_params["in"] = "header"
+                header_params["name"] = name
+                header_params["schema"] = SchemaConvertor.convert(value)
+                header_params["schema"].update(dict(example=value))
+                header_params["x-link-response"] = self.append_param_example(
+                    "headers", name, responses
+                )
                 params.append(header_params)
-        
+
         # Build Path params
         # Build cookie params
-        
         return params
-    
+
     def request_body(self):
         request_body = dict()
         request = self.request_item.get_request()
         responses = self.request_item.get_responses()
         if request.body:
             bodyschema = SchemaConvertor.convert(request.body)
-            header = request.get_headers('content-type') or '*/*'
-            request_body['content'] = {
+            header = request.get_headers("content-type") or "*/*"
+            request_body["content"] = {
                 header: {
-                    'schema': bodyschema,
-                    'example': dict(value=request.body),
-                    'x-link-response': self.append_body_example('body', request.body, responses)
+                    "schema": bodyschema,
+                    "example": dict(value=request.body),
+                    "x-link-response": self.append_body_example(
+                        "body", request.body, responses
+                    ),
                 }
             }
 

--- a/openman/spec/plugins.py
+++ b/openman/spec/plugins.py
@@ -2,85 +2,132 @@ from apispec import BasePlugin
 from apispec.exceptions import DuplicateComponentNameError
 from ..utils import camelize
 
+
 class MultiOperationBuilderPlugin(BasePlugin):
     def __init__(self, refs=False):
         self.refs = refs
-        self._reserved_keys = ['oneOf', 'allOf', 'anyOf']
-        self.counter = {'schema': {}, 'example': {}}
+        self._reserved_keys = ["oneOf", "allOf", "anyOf"]
+        self.counter = {"schema": {}, "example": {}}
 
     def init_spec(self, spec):
         super().init_spec(spec)
         self.spec = spec
         self.duplicate_schemas = {}
         self.duplicate_examples = {}
-    
+
     def add_ref_schema(self, name, schema):
-        #_name = self._get_uniq_refname('schema', name)
+        # _name = self._get_uniq_refname('schema', name)
         try:
             self.spec.components.schema(name, schema)
         except DuplicateComponentNameError as e:
-            name = self._get_uniq_refname('schema', name)
+            name = self._get_uniq_refname("schema", name)
             self.add_ref_schema(name, schema)
-        return self.spec.get_ref('schema', name)
-    
+        return self.spec.get_ref("schema", name)
+
     def add_ref_example(self, name, body):
         try:
             self.spec.components.example(name, body)
         except DuplicateComponentNameError as e:
-            name = self._get_uniq_refname('example', name)
+            name = self._get_uniq_refname("example", name)
             self.add_ref_example(name, body)
-        return self.spec.get_ref('example', name)
-    
+        return self.spec.get_ref("example", name)
+
     def _get_uniq_refname(self, key, name):
         if self.counter[key].get(name, None) is None:
             self.counter[key] = {name: 0}
             _name = name
         else:
             self.counter[key][name] += 1
-        _name = name + '_' + str(self.counter[key][name] + 1)
+        _name = name + "_" + str(self.counter[key][name] + 1)
         return _name
 
     def _fix_response_schema(self, path, operations):
         for key, value in operations.items():
-            for code, response in value.get('responses', {}).items():
-                if 'content' in response:
-                    for content_type, schema in response['content'].items():
-                        opskey = camelize(path +' '+ key + str(code)) + content_type
+            for code, response in value.get("responses", {}).items():
+                if "content" in response:
+                    for content_type, schema in response["content"].items():
+                        opskey = (
+                            camelize(path + " " + key + str(code))
+                            + content_type
+                        )
 
-                        #schemafix
+                        # schemafix
                         if self.duplicate_schemas.get(opskey, None) is None:
                             if self.refs:
-                                schema['schema'] = self.add_ref_schema('schema' +camelize(path +' '+ key + str(code)), schema['schema'])
-                            self.duplicate_schemas[opskey] = [schema['schema']]
+                                schema["schema"] = self.add_ref_schema(
+                                    "schema"
+                                    + camelize(path + " " + key + str(code)),
+                                    schema["schema"],
+                                )
+                            self.duplicate_schemas[opskey] = [schema["schema"]]
                         else:
                             if self.refs:
-                                schema['schema'] = self.add_ref_schema('schema' +camelize(path +' '+ key + str(code)), schema['schema'])
-                            self.duplicate_schemas[opskey].append(schema['schema'])
-                            schema['schema'] = dict(
-                                oneOf = [
-                                    schema for schema in self.duplicate_schemas.get(opskey)]
+                                schema["schema"] = self.add_ref_schema(
+                                    "schema"
+                                    + camelize(path + " " + key + str(code)),
+                                    schema["schema"],
+                                )
+                            self.duplicate_schemas[opskey].append(
+                                schema["schema"]
                             )
-                        #examplefix
-                        if 'examples' in schema:
-                            if self.duplicate_examples.get(opskey, None) is None:
+                            schema["schema"] = dict(
+                                oneOf=[
+                                    schema
+                                    for schema in self.duplicate_schemas.get(
+                                        opskey
+                                    )
+                                ]
+                            )
+                        # examplefix
+                        if "examples" in schema:
+                            if (
+                                self.duplicate_examples.get(opskey, None)
+                                is None
+                            ):
                                 if self.refs:
-                                    for desc, example_item in schema['examples'].items():
-                                        schema['examples'][desc] = self.add_ref_example(
-                                            'example' +camelize(path +' '+ key + str(code)),
-                                            example_item)
-                                self.duplicate_examples[opskey] = [schema['examples']]
+                                    for desc, example_item in schema[
+                                        "examples"
+                                    ].items():
+                                        schema["examples"][
+                                            desc
+                                        ] = self.add_ref_example(
+                                            "example"
+                                            + camelize(
+                                                path + " " + key + str(code)
+                                            ),
+                                            example_item,
+                                        )
+                                self.duplicate_examples[opskey] = [
+                                    schema["examples"]
+                                ]
                             else:
                                 if self.refs:
-                                    for desc, example_item in schema['examples'].items():
-                                        schema['examples'][desc] = self.add_ref_example(
-                                            'example' +camelize(path +' '+ key + str(code)),
-                                            example_item)
-                                self.duplicate_examples[opskey].append(schema['examples'])
-                                for example in self.duplicate_examples.get(opskey):
-                                    for example_name, example_value in example.items():
-                                        schema['examples'][example_name] = example_value
-    
+                                    for desc, example_item in schema[
+                                        "examples"
+                                    ].items():
+                                        schema["examples"][
+                                            desc
+                                        ] = self.add_ref_example(
+                                            "example"
+                                            + camelize(
+                                                path + " " + key + str(code)
+                                            ),
+                                            example_item,
+                                        )
+                                self.duplicate_examples[opskey].append(
+                                    schema["examples"]
+                                )
+                                for example in self.duplicate_examples.get(
+                                    opskey
+                                ):
+                                    for (
+                                        example_name,
+                                        example_value,
+                                    ) in example.items():
+                                        schema["examples"][
+                                            example_name
+                                        ] = example_value
+
     def operation_helper(self, path, operations, **kwargs):
-        """Operation helper that add `deprecated` flag if in `kwargs`
-        """
+        """Operation helper that add `deprecated` flag if in `kwargs`"""
         self._fix_response_schema(path, operations)

--- a/tests/fixtures/multi-response.json
+++ b/tests/fixtures/multi-response.json
@@ -1,0 +1,169 @@
+{
+  "info": {
+    "_postman_id": "54e215fa-5a96-4851-b066-9b8d8adf14e0",
+    "name": "Multi response API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Test MultiResponse",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"resource\": \"website\",\n    \"email\": \"me@domain.tld\",\n}"
+        },
+        "url": {
+          "raw": "{{API_HOST}}/user/setup",
+          "host": ["{{API_HOST}}"],
+          "path": ["user", "setup"]
+        }
+      },
+      "response": [
+        {
+          "name": "Setup User | Success",
+          "originalRequest": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "name": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"resource\": \"website\",\n    \"email\": \"me@domain.tld\",\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{API_HOST}}/user/setup",
+              "host": ["{{API_HOST}}"],
+              "path": ["user", "setup"]
+            }
+          },
+          "status": "OK",
+          "code": 200,
+          "_postman_previewlanguage": "json",
+          "header": null,
+          "cookie": [],
+          "body": "{\n    \"status\": \"success\",\n    \"message\": \"Setup Complete\",\n    \"username\": \"+919872371113\",\n    \"password\": \"123abc\",\n  \"url\": \"https://app.domain.tld/user_login/{random_key}?a2_iso=in\",\n}"
+        },
+        {
+          "name": "Setup user | Invalid Token",
+          "originalRequest": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "name": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"resource\": \"website\",\n    \"email\": \"me@domain.tld\",\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{API_HOST}}/user/setup",
+              "host": ["{{API_HOST}}"],
+              "path": ["user", "setup"]
+            }
+          },
+          "status": "Bad Request",
+          "code": 400,
+          "_postman_previewlanguage": "json",
+          "header": null,
+          "cookie": [],
+          "body": "{\n    \"status\": \"error\",\n    \"message\": \"invalid data - {'token': ['Invalid input.']}\"\n}"
+        },
+        {
+          "name": "Setup user | User Blacklisted",
+          "originalRequest": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "name": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"resource\": \"website\",\n    \"email\": \"me@domain.tld\",\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{API_HOST}}/user/setup",
+              "host": ["{{API_HOST}}"],
+              "path": ["user", "setup"]
+            }
+          },
+          "status": "Bad Request",
+          "code": 400,
+          "_postman_previewlanguage": "json",
+          "header": null,
+          "cookie": [],
+          "body": "{\n    \"status\": \"error\",\n    \"message\": \"Company Name is in blocked list\",\n    \"is_black_listed\": true\n}"
+        },
+        {
+          "name": "Setup user | Request Failed",
+          "originalRequest": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "name": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"resource\": \"website\",\n    \"email\": \"me@domain.tld\",\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{API_HOST}}/user/setup",
+              "host": ["{{API_HOST}}"],
+              "path": ["user", "setup"]
+            }
+          },
+          "status": "Bad Request",
+          "code": 400,
+          "_postman_previewlanguage": "json",
+          "header": null,
+          "cookie": [],
+          "body": "{\n    \"status\": \"error\",\n    \"message\": \"account api error\"\n}"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This fixes the issue of having multiple postman example for any given request.

This will allow the tool to covert those examples into `oneOf` response schema, thus making documentation better for
each given scenario